### PR TITLE
lib/nonfree-icons: reference by node_modules instead of alias

### DIFF
--- a/src/lib/nonfree-icons.ts
+++ b/src/lib/nonfree-icons.ts
@@ -11,21 +11,21 @@ const mapFromGlob = (files: FileMap): FileMap => {
 
 export const searchEngineIcons = mapFromGlob(
     import.meta.glob(
-        "$nonfree/search_engines/*.{svg,png}",
+        "../../node_modules/nonfree-icons/search_engines/*.{svg,png}",
         { eager: true, query: '?url', import: 'default' }
     )
 );
 
 export const browserIcons = mapFromGlob(
     import.meta.glob(
-        "$nonfree/browsers/*.png",
+        "../../node_modules/nonfree-icons/browsers/*.png",
         { eager: true, query: '?url', import: 'default' }
     )
 );
 
 export const passwordManagerIcons = mapFromGlob(
     import.meta.glob(
-        "$nonfree/password_managers/*.png",
+        "../../node_modules/nonfree-icons/password_managers/*.png",
         { eager: true, query: '?url', import: 'default' }
     )
 );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,11 +42,6 @@ export default defineConfig({
         grdWatcher,
         svelte(),
     ],
-    resolve: {
-        alias: {
-            $nonfree: path.resolve(__dirname, "node_modules/nonfree-icons"),
-        }
-    },
     build: {
         target: 'chrome140',
         assetsInlineLimit: (filename) => filename.endsWith('.svg')


### PR DESCRIPTION
seems to fix a build failure when developing on windows